### PR TITLE
Adjust name in license

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Neurodata Without Borders
+Copyright (c) 2024, CatalystNeuro
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
For context, since the main class of this package (the `tqdm` override) is needed by multiple upstream packages to work for GUIDE progress bar display, and because it might need future improvements/debugs - we were thinking the easiest way to integrate would be to have a simple standalone package that upstream packages rely on

Otherwise, we'd have to duplicate efforts and things might become desynchronized over time

@bendichter My question is, for the license here, is 'CatalystNeuro' OK or do we need the d.b.a.?