### PR TITLE
Fix CLI by checking args length

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,7 +10,7 @@ server_path = demo_base_path/ "server.py"
 def main():
 
     if (len(sys.argv) <= 1):
-        print("Please specify a command.")
+        print("No command provided. Please specify a command (e.g. 'demo').")
         return
     
     command = sys.argv[1]

--- a/cli.py
+++ b/cli.py
@@ -9,7 +9,12 @@ server_path = demo_base_path/ "server.py"
 
 def main():
 
+    if (len(sys.argv) <= 1):
+        print("Please specify a command.")
+        return
+    
     command = sys.argv[1]
+
     flags_list = sys.argv[2:]
 
     client_flag = "--client" in flags_list


### PR DESCRIPTION
This PR allows the CLI to gracefully exit and print a message when the user does not pass a `command`