### PR TITLE
NEP deprecate 3.8; remove parallel arguments

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
         run: pip install .[test]
 
       - name: Run full pytest with coverage
-        run: pytest -rsx --cov=./ --cov-report xml:./codecov.xml
+        run: pytest -rsx --cov=./src --cov-report xml:./codecov.xml
 
       - name: Upload full coverage to Codecov
         if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: s-weigand/setup-conda@v1
@@ -28,10 +28,10 @@ jobs:
         run: pip install .[test]
 
       - name: Run full pytest with coverage
-        run: pytest -rsx -n auto --dist loadscope --cov=./ --cov-report xml:./codecov.xml
+        run: pytest -rsx --cov=./ --cov-report xml:./codecov.xml
 
       - name: Upload full coverage to Codecov
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,5 +15,5 @@ coverage:
     patch: off
 
 ignore:
-  - "./tests/"
-  - "./demo/"
+  - "tests"
+  - "demo"


### PR DESCRIPTION
Something's up with coverage report: https://app.codecov.io/github/catalystneuro/tqdm_publisher

Only calculating coverage of the 'tests' folder...

Also apparently company will be following NEP not python deprecation cycles so dropping 3.8 here; also removing some unneeded arguments to `pytest` in an effort to debug this