### PR TITLE
Update names of classes and demo instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install tqdm_publisher
 ```
 ## Getting Started
 ### Basic Usage
-To monitor the progress of an existing `tqdm` progress bar, simply swap the `tqdm`and `TQDMPublisher` constructors. Then, declare a callback function to handle progress updates, and subscribe it to the `TQDMPublisher` updates using the `subscribe` method _before iteration begins_.
+To monitor the progress of an existing `tqdm` progress bar, simply swap the `tqdm`and `TQDMProgressPublisher` constructors. Then, declare a callback function to handle progress updates, and subscribe it to the `TQDMProgressPublisher` updates using the `subscribe` method _before iteration begins_.
 
 #### Original Code
 ```python
@@ -41,16 +41,16 @@ for duration in progress_bar:
 import random
 import time
 
-from tqdm_publisher import TQDMPublisher
+from tqdm_publisher import TQDMProgressPublisher
 
 N_TASKS = 100
 durations = [ random.uniform(0, 1.0) for _ in range(N_TASKS) ]
-progress_bar = TQDMPublisher(durations)
+progress_bar = TQDMProgressPublisher(durations)
 
 # Declare a callback function to handle progress updates
 on_update = lambda info: print('Progress Update', info)
 
-# Subscribe the callback to the TQDMPublisher
+# Subscribe the callback to the TQDMProgressPublisher
 progress_bar.subscribe(on_update)
 
 for duration in progress_bar:
@@ -58,18 +58,20 @@ for duration in progress_bar:
 ```
 
 ## Demo
-A complete demo of `tqdm_publisher` can be found in the `demo` directory, which shows how to forward progress updates from the same `TQDMPublisher` instance to multiple clients.
+A complete demo of `tqdm_publisher` can be found in the `demo` directory, which shows how to forward progress updates from the same `TQDMProgressPublisher` instance to multiple clients.
 
 To run the demo, first install the dependencies:
 ```bash
 pip install tqdm_publisher[demo]
 ```
 
-Then, run the base CLI command to start the demo server and client:
+Then, run one of the following commands to start the demo server and client with a single instance, multiple instances, or parallel instances of `TQDMProgressPublisher`:
 ```bash
-tqdm_publisher demo
+tqdm_publisher demo_single
+tqdm_publisher demo_multiple
+tqdm_publisher demo_parallel
 ```
 
-> **Note:** Alternatively, you can run each part of the demo separately by running `tqdm_publisher demo --server` and `tqdm_publisher demo --client` in separate terminals.
+<!-- > **Note:** Alternatively, you can run each part of the demo separately by running `tqdm_publisher demo --server` and `tqdm_publisher demo --client` in separate terminals. -->
 
-Finally, you can click the Create Progress Bar button to create a new `TQDMPublisher` instance, which will begin updating based on the `TQDMPublisher` instance in the Python script.
+In the opened webpage, click the "Create Progress Bar" button to create a new `TQDMProgressPublisher` instance, which will begin updating based on the `TQDMProgressPublisher` instance in the Python script.

--- a/src/tqdm_publisher/_demos/_multiple_bars/README.md
+++ b/src/tqdm_publisher/_demos/_multiple_bars/README.md
@@ -1,5 +1,5 @@
 # TQDM Publisher Multiple Bars Demo
-This demo shows how to use `tqdm_publisher` to forward progress updates from multiple `TQDMPublisher` instances to the browser.
+This demo shows how to use `tqdm_publisher` to forward progress updates from multiple `TQDMProgressPublisher` instances to the browser.
 
 ## The Approach
 This demo is nearly identical to the [single bar demo](../_single_bar/README.md), except that progress bars are managed through a scoped class definition.

--- a/src/tqdm_publisher/_demos/_parallel_bars/README.md
+++ b/src/tqdm_publisher/_demos/_parallel_bars/README.md
@@ -1,18 +1,18 @@
 # TQDM Publisher Multiple Bars Demo
-This demo shows how to use a global `TQDMPublisher` instance to forward progress updates from parallel `TQDMPublisher` instances to the browser.
+This demo shows how to use a global `TQDMProgressPublisher` instance to forward progress updates from parallel `TQDMProgressPublisher` instances to the browser.
 
 ## The Approach
-In this demo, we track multiple interdependent levels of progress updates by using a global `TQDMPublisher` instance to reflect the execution state of parallel `TQDMPublisher` instances.
+In this demo, we track multiple interdependent levels of progress updates by using a global `TQDMProgressPublisher` instance to reflect the execution state of parallel `TQDMProgressPublisher` instances.
 
 Similar to the [multiple bar demo](../_multiple_bars/README.md), a `request_id` is used to associate both the global and parallel progress bars with a specific group of elements on the browser. In particular, the ID of the global progress bar matches the `request_id`, allowing it to be distinguished from the lower-level progress bars.
 
 However, this approach also differs in many ways from the other demos:
 1. Instead of a `websockets` server, we use a `flask` server to receive requests from the client and send updates back using the Server-Sent Events (SSE) protocol.
-2. A `TQDMProgressHandler` is used to queue progress updates from parallel `TQDMPublisher` instances, avoiding the possibility of overloading the connection and receiving misformatted messages on the client.
+2. A `TQDMProgressHandler` is used to queue progress updates from parallel `TQDMProgressPublisher` instances, avoiding the possibility of overloading the connection and receiving misformatted messages on the client.
 
 ## Handling Processes
 Since our `TQDMProgressHandler` is managing progress bars across processes, we're using it in an unconventional way.
 
-Instead of using the handler to directly manage `TQDMSubscriber` instances, we declare `TQDMPublisher` instances within the process.
+Instead of using the handler to directly manage `TQDMProgressSubscriber` instances, we declare `TQDMProgressPublisher` instances within the process.
 
 Since we can't pass data directly out of the process, we send an HTTP request to the `flask` server that is directly forwarded to the handler's `announce` method.

--- a/src/tqdm_publisher/_demos/_single_bar/README.md
+++ b/src/tqdm_publisher/_demos/_single_bar/README.md
@@ -1,9 +1,9 @@
 # TQDM Publisher Single Bar Demo
-This demo shows how to use `tqdm_publisher` to forward progress updates from a single `TQDMPublisher` instance to the browser.
+This demo shows how to use `tqdm_publisher` to forward progress updates from a single `TQDMProgressPublisher` instance to the browser.
 
 ## The Approach
 We use `websockets` to establish a connection between the server and the client.
 
-A progress bar is pre-rendered on page load. When the client presses the Create Progress Bar button, the server forwards progress updates to the client using a `TQDMPublisher` instance spawned in a separate thread.
+A progress bar is pre-rendered on page load. When the client presses the Create Progress Bar button, the server forwards progress updates to the client using a `TQDMProgressPublisher` instance spawned in a separate thread.
 
 The Create button is disabled until the progress bar is finished to avoid associating updates from multiple progress bars with their respective elements.

--- a/src/tqdm_publisher/_publisher.py
+++ b/src/tqdm_publisher/_publisher.py
@@ -46,7 +46,7 @@ class TQDMProgressPublisher(base_tqdm):
         >>> def my_callback(format_dict):
         >>>     print("Progress update", format_dict)
         >>>
-        >>> publisher = TQDMPublisher()
+        >>> publisher = TQDMProgressPublisher()
         >>> callback_id = publisher.subscribe(my_callback)
         >>> print(callback_id)  # Prints the unique callback ID
         """
@@ -79,7 +79,7 @@ class TQDMProgressPublisher(base_tqdm):
 
         Examples
         --------
-        >>> publisher = TQDMPublisher()
+        >>> publisher = TQDMProgressPublisher()
         >>> callback_id = publisher.subscribe(my_callback)
         >>> print(callback_id)  # Prints the unique callback ID
         >>> unsubscribed = publisher.unsubscribe(callback_id)


### PR DESCRIPTION
I noticed the example code and demo instructions in the README were out of date and tried to fix them here.